### PR TITLE
Allow configuration of default wrapping for unannotated indexed properties

### DIFF
--- a/jackson-xml/src/main/java/io/micronaut/xml/jackson/JacksonXmlConfiguration.java
+++ b/jackson-xml/src/main/java/io/micronaut/xml/jackson/JacksonXmlConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.micronaut.xml.jackson;
 
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlAnnotationIntrospector;
 import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import io.micronaut.context.annotation.ConfigurationProperties;
@@ -38,6 +39,7 @@ import java.util.Map;
 public class JacksonXmlConfiguration {
     private Map<FromXmlParser.Feature, Boolean> parser = Collections.emptyMap();
     private Map<ToXmlGenerator.Feature, Boolean> generator = Collections.emptyMap();
+    private boolean defaultUseWrapper = JacksonXmlAnnotationIntrospector.DEFAULT_USE_WRAPPER;
 
     /**
      * @return Settings for the parser
@@ -71,5 +73,20 @@ public class JacksonXmlConfiguration {
         if (CollectionUtils.isNotEmpty(generator)) {
             this.generator = generator;
         }
+    }
+
+    /**
+     * @return True if default wrapper is used
+     * */
+    public boolean isDefaultUseWrapper() {
+        return defaultUseWrapper;
+    }
+
+    /**
+     * Define if a wrapper will be used for indexed (List, array) properties or not by default.
+     * @param state True if wrapping is used by default
+     */
+    public void setDefaultUseWrapper(boolean state) {
+        this.defaultUseWrapper = state;
     }
 }

--- a/jackson-xml/src/main/java/io/micronaut/xml/jackson/server/convert/XmlMapperFactory.java
+++ b/jackson-xml/src/main/java/io/micronaut/xml/jackson/server/convert/XmlMapperFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Factory;
@@ -67,6 +68,7 @@ public class XmlMapperFactory {
      * Builds the core Jackson {@link ObjectMapper} from the optional configuration and {@link com.fasterxml.jackson.core.JsonFactory}.
      *
      * @param jacksonConfiguration The configuration
+     * @param xmlConfiguration The XML configuration
      * @return The {@link ObjectMapper}
      */
     @Singleton
@@ -74,7 +76,13 @@ public class XmlMapperFactory {
     @Named("xml")
     public XmlMapper xmlMapper(@Nullable JacksonConfiguration jacksonConfiguration, @Nullable JacksonXmlConfiguration xmlConfiguration) {
 
-        XmlMapper objectMapper = new XmlMapper();
+        final boolean hasXmlConfiguration = xmlConfiguration != null;
+        JacksonXmlModule xmlModule = new JacksonXmlModule();
+        if (hasXmlConfiguration) {
+            xmlModule.setDefaultUseWrapper(xmlConfiguration.isDefaultUseWrapper());
+        }
+
+        XmlMapper objectMapper = new XmlMapper(xmlModule);
 
         final boolean hasConfiguration = jacksonConfiguration != null;
         if (!hasConfiguration || jacksonConfiguration.isModuleScan()) {
@@ -128,7 +136,7 @@ public class XmlMapperFactory {
             jacksonConfiguration.getGeneratorSettings().forEach(objectMapper::configure);
         }
 
-        if (xmlConfiguration != null) {
+        if (hasXmlConfiguration) {
             xmlConfiguration.getParserSettings().forEach(objectMapper::configure);
             xmlConfiguration.getGeneratorSettings().forEach(objectMapper::configure);
         }

--- a/jackson-xml/src/test/groovy/io/micronaut/xml/jackson/server/XmlMapperSetupSpec.groovy
+++ b/jackson-xml/src/test/groovy/io/micronaut/xml/jackson/server/XmlMapperSetupSpec.groovy
@@ -1,6 +1,6 @@
 package io.micronaut.xml.jackson.server
 /*
- * Copyright 2017-2019 original authors
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,5 +49,35 @@ class XmlMapperSetupSpec extends Specification {
 
         and: "generated XML is prefixed with XML declaration"
         mapper.writeValueAsString(['1']) == "<?xml version='1.0' encoding='UTF-8'?><ArrayList><item>1</item></ArrayList>"
+    }
+
+    void 'verify can disable to use wrapper by default'() {
+        when: "Object Mapper is configured with non-default using wrapper"
+        ApplicationContext applicationContext = ApplicationContext.run(["jackson.xml.defaultUseWrapper": false], 'test', 'xml').start()
+        ObjectMapper mapper = applicationContext.getBean(ObjectMapper, Qualifiers.byName('xml'))
+
+        then: "define class and serialize to XML using mappers"
+        Container container = new Container(["A", "B"])
+        mapper.writeValueAsString(container) ==
+                "<?xml version='1.0' encoding='UTF-8'?><Container><items>A</items><items>B</items></Container>"
+    }
+
+    void 'verify can enable to use wrapper by default'() {
+        when: "Object Mapper is configured with non-default using wrapper"
+        ApplicationContext applicationContext = ApplicationContext.run(["jackson.xml.defaultUseWrapper": true], 'test', 'xml')
+        ObjectMapper mapper = applicationContext.getBean(ObjectMapper, Qualifiers.byName('xml'))
+
+        then: "define class and serialize to XML using mappers"
+        Container container = new Container(["A", "B"])
+        mapper.writeValueAsString(container) ==
+                "<?xml version='1.0' encoding='UTF-8'?><Container><items><items>A</items><items>B</items></items></Container>"
+    }
+
+    static class Container {
+        List<String> items
+
+        Container(List<String> items) {
+            this.items = items
+        }
     }
 }


### PR DESCRIPTION
The default behavior is to assume use of List wrapper if no annotations `@JacksonXmlElementWrapper` are used.
For example:
```xml
<?xml version='1.0' encoding='UTF-8'?>
<Container>
    <items>
        <items>A</items>
        <items>B</items>
    </items>
</Container>
```
In some cases it should be changed to `false`
```xml
<?xml version='1.0' encoding='UTF-8'?>
<Container>
    <items>A</items>
    <items>B</items>
</Container>
```