### PR TITLE
Add BOM module

### DIFF
--- a/jackson-bom/build.gradle
+++ b/jackson-bom/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id("io.micronaut.build.internal.bom")
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabled = providers.provider {
+            def (major, minor, _) = project.version.split("\\.")
+            major.toInteger() >= 4 && minor.toInteger() > 0
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,7 @@ plugins {
 
 rootProject.name = "jackson-xml-parent"
 
+include 'jackson-bom'
 include 'jackson-xml'
 
 micronautBuild {


### PR DESCRIPTION
Once this is done, we can replace the inclusion of the library with the BOM in `micronaut-platform`.